### PR TITLE
Default theme never added to theme list in ST3

### DIFF
--- a/themr.py
+++ b/themr.py
@@ -8,21 +8,24 @@ class Themr():
 	def load_themes(self):
 		themes = []
 
-		for root, dirs, files in os.walk(sublime.packages_path()):
-			for filename in (filename for filename in files if filename.endswith('.sublime-theme')):
-				name = filename.replace('.sublime-theme', '')
+		if int(sublime.version()) < 3000:
+			for root, dirs, files in os.walk(sublime.packages_path()):
+				for filename in (filename for filename in files if filename.endswith('.sublime-theme')):
+					name = filename.replace('.sublime-theme', '')
+					themes.append(['Theme: ' + name, filename])
+
+			for root, dirs, files in os.walk(sublime.installed_packages_path()):
+				for package in (package for package in files if package.endswith('.sublime-package')):
+					zf = zipfile.ZipFile(os.path.join(sublime.installed_packages_path(), package))
+					for filename in (filename for filename in zf.namelist() if filename.endswith('.sublime-theme')):
+						name = os.path.basename(filename).replace('.sublime-theme', '')
+						themes.append(["Theme: " + name, filename])
+
+		else:
+			for theme_resource in sublime.find_resources("*.sublime-theme"):
+				filename = os.path.basename(theme_resource)
+				name = os.path.splitext(filename)[0]
 				themes.append(['Theme: ' + name, filename])
-
-		for root, dirs, files in os.walk(sublime.installed_packages_path()):
-			for package in (package for package in files if package.endswith('.sublime-package')):
-				zf = zipfile.ZipFile(os.path.join(sublime.installed_packages_path(), package))
-				for filename in (filename for filename in zf.namelist() if filename.endswith('.sublime-theme')):
-					name = os.path.basename(filename).replace('.sublime-theme', '')
-					themes.append(["Theme: " + name, filename])
-
-		default_theme = os.path.join(os.getcwd(), 'Packages', 'Theme - Default.sublime-package')
-		if os.path.exists(default_theme):
-			themes.append(["Theme: Default", "Default.sublime-theme"])
 
 		themes.sort()
 		return themes


### PR DESCRIPTION
In Sublime Text 3, Themr would never add the default theme to the theme list. This is caused by Themr checking for the existence of the default theme file in the packages directory before it adds the default theme to the list. However, in ST3, the default theme is contained in the default packages zip file in ST's application directory. This meant Themr would never find the default theme file, and never add it to the list.

The commit in this pull request simply gets rid of that file check before adding the default theme to the list. It's a pretty safe bet that the default theme will always exist, so there's not much harm in getting rid of that check.
